### PR TITLE
Change nethvoice-module-nethvplan name for NethVoice11

### DIFF
--- a/nethserver-enterprise-groups.xml.in
+++ b/nethserver-enterprise-groups.xml.in
@@ -950,7 +950,7 @@
       <packagereq type="mandatory">nethvoice-module-nethvoipwizard</packagereq>
       <packagereq type="mandatory">nethvoice-module-nethwizard</packagereq>
       <packagereq type="mandatory">nethserver-backup-data</packagereq>
-      <packagereq type="mandatory">nethvoice-module-nethvplan</packagereq>
+      <packagereq type="mandatory">nethvoice-module-nethvplan11</packagereq>
       <packagereq type="mandatory">nethvoice-module-nethbulkextensions</packagereq>
       <packagereq type="mandatory">nethvoice-module-nethnight</packagereq>
       <packagereq type="optional">nethvoice-module-nethvirtualtrunks</packagereq>


### PR DESCRIPTION
nethvoice-module-nethvplan is now obsoleted by nethvoice-module-nethvplan11