### PR TITLE
Remove backup-data from nethvoice 11

### DIFF
--- a/nethserver-enterprise-groups.xml.in
+++ b/nethserver-enterprise-groups.xml.in
@@ -950,7 +950,6 @@
       <packagereq type="mandatory">nethvoice-module-nethgateway</packagereq>
       <packagereq type="mandatory">nethvoice-module-nethvoipwizard</packagereq>
       <packagereq type="mandatory">nethvoice-module-nethwizard</packagereq>
-      <packagereq type="mandatory">nethserver-backup-data</packagereq>
       <packagereq type="mandatory">nethvoice-module-nethvplan11</packagereq>
       <packagereq type="mandatory">nethvoice-module-nethbulkextensions</packagereq>
       <packagereq type="mandatory">nethvoice-module-nethnight</packagereq>


### PR DESCRIPTION
The backup package should be part only of backup group itself.
In fact nethvoice 14 group doesn't contain it.

This fix also allow the correct visualization of group package/groups inside cockpit.