### PR TITLE
comps. added restore-data group

### DIFF
--- a/nethserver-enterprise-groups.xml.in
+++ b/nethserver-enterprise-groups.xml.in
@@ -1135,6 +1135,7 @@
       <groupid>buildsys-build</groupid>
       <groupid>nethserver-iso</groupid>
       <groupid>nethserver-backup</groupid>
+      <groupid>nethserver-restore-data</groupid>
       <groupid>nethserver-nut</groupid>
       <groupid>nethserver-ntp</groupid>
       <groupid>nethserver-phonebook</groupid>

--- a/nethserver-enterprise-groups.xml.in
+++ b/nethserver-enterprise-groups.xml.in
@@ -417,6 +417,16 @@
     <packagelist>
       <packagereq type="mandatory">nethserver-backup-config</packagereq>
       <packagereq type="mandatory">nethserver-backup-data</packagereq>
+    </packagelist>
+  </group>
+
+  <group>
+    <id>nethserver-restore-data</id>
+    <_name>Backup restore</_name>
+    <_description>Module to restore backup of data</_description>
+    <default>false</default>
+    <uservisible>true</uservisible>
+    <packagelist>
       <packagereq type="mandatory">nethserver-restore-data</packagereq>
     </packagelist>
   </group>

--- a/po/comps.pot
+++ b/po/comps.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-07-03 15:50+0200\n"
+"POT-Creation-Date: 2019-10-02 15:06+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -38,477 +38,485 @@ msgid "Backup of configuration and data"
 msgstr ""
 
 #: ../nethserver-enterprise-groups.xml.in.h:6
-msgid "Fax server"
+msgid "Backup restore"
 msgstr ""
 
 #: ../nethserver-enterprise-groups.xml.in.h:7
-msgid "Configure HylaFax+ and manage IAX modems"
+msgid "Module to restore backup of data"
 msgstr ""
 
 #: ../nethserver-enterprise-groups.xml.in.h:8
-msgid "Basic firewall"
+msgid "Fax server"
 msgstr ""
 
 #: ../nethserver-enterprise-groups.xml.in.h:9
-msgid "Configure network adapters and basic firewall"
+msgid "Configure HylaFax+ and manage IAX modems"
 msgstr ""
 
 #: ../nethserver-enterprise-groups.xml.in.h:10
-msgid "File server"
+msgid "Basic firewall"
 msgstr ""
 
 #: ../nethserver-enterprise-groups.xml.in.h:11
-msgid "Daemons and tools for network file sharing"
+msgid "Configure network adapters and basic firewall"
 msgstr ""
 
 #: ../nethserver-enterprise-groups.xml.in.h:12
-msgid "FTP server"
+msgid "File server"
 msgstr ""
 
 #: ../nethserver-enterprise-groups.xml.in.h:13
-msgid "Configure the FTP server (vsftpd)"
+msgid "Daemons and tools for network file sharing"
 msgstr ""
 
 #: ../nethserver-enterprise-groups.xml.in.h:14
-msgid "Account provider: OpenLDAP"
+msgid "FTP server"
 msgstr ""
 
 #: ../nethserver-enterprise-groups.xml.in.h:15
-msgid "Configure users and groups on OpenLDAP"
+msgid "Configure the FTP server (vsftpd)"
 msgstr ""
 
 #: ../nethserver-enterprise-groups.xml.in.h:16
-msgid "Account provider: Samba Active Directory"
+msgid "Account provider: OpenLDAP"
 msgstr ""
 
 #: ../nethserver-enterprise-groups.xml.in.h:17
-msgid "Configure users and groups on Samba Active Directory"
+msgid "Configure users and groups on OpenLDAP"
 msgstr ""
 
 #: ../nethserver-enterprise-groups.xml.in.h:18
-msgid "WebTop 5 groupware"
+msgid "Account provider: Samba Active Directory"
 msgstr ""
 
 #: ../nethserver-enterprise-groups.xml.in.h:19
-msgid "Email"
+msgid "Configure users and groups on Samba Active Directory"
 msgstr ""
 
 #: ../nethserver-enterprise-groups.xml.in.h:20
-msgid "Email server and filter"
+msgid "WebTop 5 groupware"
 msgstr ""
 
 #: ../nethserver-enterprise-groups.xml.in.h:21
-msgid "Roundcube web mail"
+msgid "Email"
 msgstr ""
 
 #: ../nethserver-enterprise-groups.xml.in.h:22
-msgid "SMTP proxy"
+msgid "Email server and filter"
 msgstr ""
 
 #: ../nethserver-enterprise-groups.xml.in.h:23
-msgid "Filter SMTP traffic with ClamAV and Rspamd"
+msgid "Roundcube web mail"
 msgstr ""
 
 #: ../nethserver-enterprise-groups.xml.in.h:24
-msgid "Instant messaging"
+msgid "SMTP proxy"
 msgstr ""
 
 #: ../nethserver-enterprise-groups.xml.in.h:25
-msgid "XMPP/Jabber chat server"
+msgid "Filter SMTP traffic with ClamAV and Rspamd"
 msgstr ""
 
 #: ../nethserver-enterprise-groups.xml.in.h:26
-msgid "Print server"
+msgid "Instant messaging"
 msgstr ""
 
 #: ../nethserver-enterprise-groups.xml.in.h:27
-msgid "Print management server (CUPS)"
+msgid "XMPP/Jabber chat server"
 msgstr ""
 
 #: ../nethserver-enterprise-groups.xml.in.h:28
-msgid "Web server"
+msgid "Print server"
 msgstr ""
 
 #: ../nethserver-enterprise-groups.xml.in.h:29
-msgid "Configuration tools for Apache web server"
+msgid "Print management server (CUPS)"
 msgstr ""
 
 #: ../nethserver-enterprise-groups.xml.in.h:30
-msgid "Reverse proxy"
+msgid "Web server"
 msgstr ""
 
 #: ../nethserver-enterprise-groups.xml.in.h:31
-msgid "Configure Apache ProxyPass functionality"
+msgid "Configuration tools for Apache web server"
 msgstr ""
 
 #: ../nethserver-enterprise-groups.xml.in.h:32
-msgid "Bandwidth monitor"
+msgid "Reverse proxy"
 msgstr ""
 
 #: ../nethserver-enterprise-groups.xml.in.h:33
-msgid "Configure and manage Ntopng"
+msgid "Configure Apache ProxyPass functionality"
 msgstr ""
 
 #: ../nethserver-enterprise-groups.xml.in.h:34
-msgid "UPS support"
+msgid "Bandwidth monitor"
 msgstr ""
 
 #: ../nethserver-enterprise-groups.xml.in.h:35
-msgid "UPS management and monitoring configuration"
+msgid "Configure and manage Ntopng"
 msgstr ""
 
 #: ../nethserver-enterprise-groups.xml.in.h:36
-msgid "Statistics"
+msgid "UPS support"
 msgstr ""
 
 #: ../nethserver-enterprise-groups.xml.in.h:37
-msgid "Collect and analyse system statistics"
+msgid "UPS management and monitoring configuration"
 msgstr ""
 
 #: ../nethserver-enterprise-groups.xml.in.h:38
-msgid "Web proxy"
+msgid "Statistics"
 msgstr ""
 
 #: ../nethserver-enterprise-groups.xml.in.h:39
-msgid "Squid web caching proxy configuration"
+msgid "Collect and analyse system statistics"
 msgstr ""
 
 #: ../nethserver-enterprise-groups.xml.in.h:40
-msgid "Web filter"
+msgid "Web proxy"
 msgstr ""
 
 #: ../nethserver-enterprise-groups.xml.in.h:41
-msgid "Squid web content and virus filter"
+msgid "Squid web caching proxy configuration"
 msgstr ""
 
 #: ../nethserver-enterprise-groups.xml.in.h:42
+msgid "Web filter"
+msgstr ""
+
+#: ../nethserver-enterprise-groups.xml.in.h:43
+msgid "Squid web content and virus filter"
+msgstr ""
+
+#: ../nethserver-enterprise-groups.xml.in.h:44
 msgid ""
 "Configure remote-access and site-to-site Virtual Private Networks (VPN) "
 "using OpenVPN"
 msgstr ""
 
-#: ../nethserver-enterprise-groups.xml.in.h:43
+#: ../nethserver-enterprise-groups.xml.in.h:45
 msgid "IPsec tunnels"
 msgstr ""
 
-#: ../nethserver-enterprise-groups.xml.in.h:44
+#: ../nethserver-enterprise-groups.xml.in.h:46
 msgid "Site-to-site Virtual Private Networks (VPN) using IPsec"
 msgstr ""
 
-#: ../nethserver-enterprise-groups.xml.in.h:45
+#: ../nethserver-enterprise-groups.xml.in.h:47
 msgid "MariaDB (MySQL) server"
 msgstr ""
 
-#: ../nethserver-enterprise-groups.xml.in.h:46
+#: ../nethserver-enterprise-groups.xml.in.h:48
 msgid "Configuration tools for MariaDB (MySQL)"
 msgstr ""
 
-#: ../nethserver-enterprise-groups.xml.in.h:47
+#: ../nethserver-enterprise-groups.xml.in.h:49
 msgid "Intrusion Prevention System"
 msgstr ""
 
-#: ../nethserver-enterprise-groups.xml.in.h:48
+#: ../nethserver-enterprise-groups.xml.in.h:50
 msgid "Monitor and block network traffic for malicious activity"
 msgstr ""
 
-#: ../nethserver-enterprise-groups.xml.in.h:49
+#: ../nethserver-enterprise-groups.xml.in.h:51
 msgid "Deep packet inspection (DPI)"
 msgstr ""
 
-#: ../nethserver-enterprise-groups.xml.in.h:50
+#: ../nethserver-enterprise-groups.xml.in.h:52
 msgid "Filter network traffic by analyzing the packets payload"
 msgstr ""
 
-#: ../nethserver-enterprise-groups.xml.in.h:51
+#: ../nethserver-enterprise-groups.xml.in.h:53
 msgid "POP3 proxy"
 msgstr ""
 
-#: ../nethserver-enterprise-groups.xml.in.h:52
+#: ../nethserver-enterprise-groups.xml.in.h:54
 msgid "Intercept POP3 connections and scan messages for virus and spam"
 msgstr ""
 
-#: ../nethserver-enterprise-groups.xml.in.h:53
+#: ../nethserver-enterprise-groups.xml.in.h:55
 msgid "SNMP server"
 msgstr ""
 
-#: ../nethserver-enterprise-groups.xml.in.h:54
+#: ../nethserver-enterprise-groups.xml.in.h:56
 msgid "Configure the SNMP server"
 msgstr ""
 
-#: ../nethserver-enterprise-groups.xml.in.h:55
+#: ../nethserver-enterprise-groups.xml.in.h:57
 msgid "Nextcloud"
 msgstr ""
 
-#: ../nethserver-enterprise-groups.xml.in.h:56
+#: ../nethserver-enterprise-groups.xml.in.h:58
 msgid ""
 "Configure Nextcloud, universal access to your files via the web, your "
 "computer or your mobile devices - wherever you are"
 msgstr ""
 
-#: ../nethserver-enterprise-groups.xml.in.h:57
+#: ../nethserver-enterprise-groups.xml.in.h:59
 msgid "POP3 connector"
 msgstr ""
 
-#: ../nethserver-enterprise-groups.xml.in.h:58
+#: ../nethserver-enterprise-groups.xml.in.h:60
 msgid "Fetch messages from external email accounts with POP3 or IMAP access"
 msgstr ""
 
-#: ../nethserver-enterprise-groups.xml.in.h:59
+#: ../nethserver-enterprise-groups.xml.in.h:61
 msgid "German language"
 msgstr ""
 
-#: ../nethserver-enterprise-groups.xml.in.h:60
+#: ../nethserver-enterprise-groups.xml.in.h:62
 msgid "Server Manager German localization"
 msgstr ""
 
-#: ../nethserver-enterprise-groups.xml.in.h:61
+#: ../nethserver-enterprise-groups.xml.in.h:63
 msgid "Greek language"
 msgstr ""
 
-#: ../nethserver-enterprise-groups.xml.in.h:62
+#: ../nethserver-enterprise-groups.xml.in.h:64
 msgid "Server Manager Greek localization"
 msgstr ""
 
-#: ../nethserver-enterprise-groups.xml.in.h:63
+#: ../nethserver-enterprise-groups.xml.in.h:65
 msgid "Spanish language"
 msgstr ""
 
-#: ../nethserver-enterprise-groups.xml.in.h:64
+#: ../nethserver-enterprise-groups.xml.in.h:66
 msgid "Server Manager Spanish localization"
 msgstr ""
 
-#: ../nethserver-enterprise-groups.xml.in.h:65
+#: ../nethserver-enterprise-groups.xml.in.h:67
 msgid "French language"
 msgstr ""
 
-#: ../nethserver-enterprise-groups.xml.in.h:66
+#: ../nethserver-enterprise-groups.xml.in.h:68
 msgid "Server Manager French localization"
 msgstr ""
 
-#: ../nethserver-enterprise-groups.xml.in.h:67
+#: ../nethserver-enterprise-groups.xml.in.h:69
 msgid "Hungarian language"
 msgstr ""
 
-#: ../nethserver-enterprise-groups.xml.in.h:68
+#: ../nethserver-enterprise-groups.xml.in.h:70
 msgid "Server Manager Hungarian localization"
 msgstr ""
 
-#: ../nethserver-enterprise-groups.xml.in.h:69
+#: ../nethserver-enterprise-groups.xml.in.h:71
 msgid "Italian language"
 msgstr ""
 
-#: ../nethserver-enterprise-groups.xml.in.h:70
+#: ../nethserver-enterprise-groups.xml.in.h:72
 msgid "Server Manager Italian localization"
 msgstr ""
 
-#: ../nethserver-enterprise-groups.xml.in.h:71
+#: ../nethserver-enterprise-groups.xml.in.h:73
 msgid "Dutch language"
 msgstr ""
 
-#: ../nethserver-enterprise-groups.xml.in.h:72
+#: ../nethserver-enterprise-groups.xml.in.h:74
 msgid "Server Manager Dutch localization"
 msgstr ""
 
-#: ../nethserver-enterprise-groups.xml.in.h:73
+#: ../nethserver-enterprise-groups.xml.in.h:75
 msgid "Portuguese language"
 msgstr ""
 
-#: ../nethserver-enterprise-groups.xml.in.h:74
+#: ../nethserver-enterprise-groups.xml.in.h:76
 msgid "Server Manager Portuguese localization"
 msgstr ""
 
-#: ../nethserver-enterprise-groups.xml.in.h:75
+#: ../nethserver-enterprise-groups.xml.in.h:77
 msgid "Russian language"
 msgstr ""
 
-#: ../nethserver-enterprise-groups.xml.in.h:76
+#: ../nethserver-enterprise-groups.xml.in.h:78
 msgid "Server Manager Russian localization"
 msgstr ""
 
-#: ../nethserver-enterprise-groups.xml.in.h:77
+#: ../nethserver-enterprise-groups.xml.in.h:79
 msgid "Turkish language"
 msgstr ""
 
-#: ../nethserver-enterprise-groups.xml.in.h:78
+#: ../nethserver-enterprise-groups.xml.in.h:80
 msgid "Server Manager Turkish localization"
 msgstr ""
 
-#: ../nethserver-enterprise-groups.xml.in.h:79
+#: ../nethserver-enterprise-groups.xml.in.h:81
 msgid "Serbian language"
 msgstr ""
 
-#: ../nethserver-enterprise-groups.xml.in.h:80
+#: ../nethserver-enterprise-groups.xml.in.h:82
 msgid "Server Manager Serbian localization"
 msgstr ""
 
-#: ../nethserver-enterprise-groups.xml.in.h:81
+#: ../nethserver-enterprise-groups.xml.in.h:83
 msgid "Phonebook"
 msgstr ""
 
-#: ../nethserver-enterprise-groups.xml.in.h:82
+#: ../nethserver-enterprise-groups.xml.in.h:84
 msgid "Centralized Phonebook"
 msgstr ""
 
-#: ../nethserver-enterprise-groups.xml.in.h:83
+#: ../nethserver-enterprise-groups.xml.in.h:85
 msgid "Centralized HotSpot"
 msgstr ""
 
-#: ../nethserver-enterprise-groups.xml.in.h:84
+#: ../nethserver-enterprise-groups.xml.in.h:86
 msgid "Portal for centralized hotspot configuration"
 msgstr ""
 
-#: ../nethserver-enterprise-groups.xml.in.h:85
+#: ../nethserver-enterprise-groups.xml.in.h:87
 msgid "Cloud content filter"
 msgstr ""
 
-#: ../nethserver-enterprise-groups.xml.in.h:86
+#: ../nethserver-enterprise-groups.xml.in.h:88
 msgid "Cloud-based web content filter"
 msgstr ""
 
-#: ../nethserver-enterprise-groups.xml.in.h:87
+#: ../nethserver-enterprise-groups.xml.in.h:89
 msgid "Weekly report"
 msgstr ""
 
-#: ../nethserver-enterprise-groups.xml.in.h:88
+#: ../nethserver-enterprise-groups.xml.in.h:90
 msgid "Weekly report about system status"
 msgstr ""
 
-#: ../nethserver-enterprise-groups.xml.in.h:89
+#: ../nethserver-enterprise-groups.xml.in.h:91
 msgid "NethSecurity 1.5 migration"
 msgstr ""
 
-#: ../nethserver-enterprise-groups.xml.in.h:90
+#: ../nethserver-enterprise-groups.xml.in.h:92
 msgid "Migrations tools from NethSecurity 1.5"
 msgstr ""
 
-#: ../nethserver-enterprise-groups.xml.in.h:91
+#: ../nethserver-enterprise-groups.xml.in.h:93
 msgid "NethVoice 11"
 msgstr ""
 
-#: ../nethserver-enterprise-groups.xml.in.h:92
+#: ../nethserver-enterprise-groups.xml.in.h:94
 msgid "Asterisk PBX"
 msgstr ""
 
-#: ../nethserver-enterprise-groups.xml.in.h:93
+#: ../nethserver-enterprise-groups.xml.in.h:95
 msgid "NethVoice 14 with NethCTI 3"
 msgstr ""
 
-#: ../nethserver-enterprise-groups.xml.in.h:94
+#: ../nethserver-enterprise-groups.xml.in.h:96
 msgid "PBX configuration with Computer Telephony Integration web application"
 msgstr ""
 
-#: ../nethserver-enterprise-groups.xml.in.h:95
+#: ../nethserver-enterprise-groups.xml.in.h:97
 msgid "NethCTI QManager"
 msgstr ""
 
-#: ../nethserver-enterprise-groups.xml.in.h:96
+#: ../nethserver-enterprise-groups.xml.in.h:98
 msgid "Queue Manager is the application for queue supervisor"
 msgstr ""
 
-#: ../nethserver-enterprise-groups.xml.in.h:97
+#: ../nethserver-enterprise-groups.xml.in.h:99
 msgid "NethCTI 2"
 msgstr ""
 
-#: ../nethserver-enterprise-groups.xml.in.h:98
+#: ../nethserver-enterprise-groups.xml.in.h:100
 msgid "Computer Telephony Integration"
 msgstr ""
 
-#: ../nethserver-enterprise-groups.xml.in.h:99
+#: ../nethserver-enterprise-groups.xml.in.h:101
 msgid "NethHotel 11"
 msgstr ""
 
-#: ../nethserver-enterprise-groups.xml.in.h:100
+#: ../nethserver-enterprise-groups.xml.in.h:102
 msgid "Hotel Management Interface"
 msgstr ""
 
-#: ../nethserver-enterprise-groups.xml.in.h:101
+#: ../nethserver-enterprise-groups.xml.in.h:103
 msgid "Mattermost"
 msgstr ""
 
-#: ../nethserver-enterprise-groups.xml.in.h:102
+#: ../nethserver-enterprise-groups.xml.in.h:104
 msgid "Mattermost Team Edition"
 msgstr ""
 
-#: ../nethserver-enterprise-groups.xml.in.h:103
+#: ../nethserver-enterprise-groups.xml.in.h:105
 msgid "NethSpot"
 msgstr ""
 
-#: ../nethserver-enterprise-groups.xml.in.h:104
+#: ../nethserver-enterprise-groups.xml.in.h:106
 msgid "Nethesis Hotspot"
 msgstr ""
 
-#: ../nethserver-enterprise-groups.xml.in.h:105
+#: ../nethserver-enterprise-groups.xml.in.h:107
 msgid "NethSpot Integrations"
 msgstr ""
 
-#: ../nethserver-enterprise-groups.xml.in.h:106
+#: ../nethserver-enterprise-groups.xml.in.h:108
 msgid "NethSpot extra integrations"
 msgstr ""
 
-#: ../nethserver-enterprise-groups.xml.in.h:107
+#: ../nethserver-enterprise-groups.xml.in.h:109
 msgid "Fail2ban"
 msgstr ""
 
-#: ../nethserver-enterprise-groups.xml.in.h:108
+#: ../nethserver-enterprise-groups.xml.in.h:110
 msgid "Fail2ban scans log files and bans IPs with failed login"
 msgstr ""
 
-#: ../nethserver-enterprise-groups.xml.in.h:109
+#: ../nethserver-enterprise-groups.xml.in.h:111
 msgid "New Server Manager (Beta)"
 msgstr ""
 
-#: ../nethserver-enterprise-groups.xml.in.h:110
+#: ../nethserver-enterprise-groups.xml.in.h:112
 msgid "New Server Manager based on Cockpit"
 msgstr ""
 
-#: ../nethserver-enterprise-groups.xml.in.h:111
+#: ../nethserver-enterprise-groups.xml.in.h:113
 msgid "Netdata"
 msgstr ""
 
-#: ../nethserver-enterprise-groups.xml.in.h:112
+#: ../nethserver-enterprise-groups.xml.in.h:114
 msgid "Real-time performance monitoring"
 msgstr ""
 
-#: ../nethserver-enterprise-groups.xml.in.h:113
+#: ../nethserver-enterprise-groups.xml.in.h:115
 msgid "Report (Beta)"
 msgstr ""
 
-#: ../nethserver-enterprise-groups.xml.in.h:114
+#: ../nethserver-enterprise-groups.xml.in.h:116
 msgid "Reports on system usage"
 msgstr ""
 
-#: ../nethserver-enterprise-groups.xml.in.h:115
+#: ../nethserver-enterprise-groups.xml.in.h:117
 msgid "Base system"
 msgstr ""
 
-#: ../nethserver-enterprise-groups.xml.in.h:116
+#: ../nethserver-enterprise-groups.xml.in.h:118
 msgid "Common packages to all products"
 msgstr ""
 
-#: ../nethserver-enterprise-groups.xml.in.h:117
+#: ../nethserver-enterprise-groups.xml.in.h:119
 msgid "NethService"
 msgstr ""
 
-#: ../nethserver-enterprise-groups.xml.in.h:118
+#: ../nethserver-enterprise-groups.xml.in.h:120
 msgid "Small and Medium Enterprises (SME) oriented Linux distribution"
 msgstr ""
 
-#: ../nethserver-enterprise-groups.xml.in.h:119
+#: ../nethserver-enterprise-groups.xml.in.h:121
 msgid "NethSecurity"
 msgstr ""
 
-#: ../nethserver-enterprise-groups.xml.in.h:120
+#: ../nethserver-enterprise-groups.xml.in.h:122
 msgid "UTM Firewall"
 msgstr ""
 
-#: ../nethserver-enterprise-groups.xml.in.h:121
+#: ../nethserver-enterprise-groups.xml.in.h:123
 msgid "NethVoice"
 msgstr ""
 
-#: ../nethserver-enterprise-groups.xml.in.h:122
+#: ../nethserver-enterprise-groups.xml.in.h:124
 msgid "Languages"
 msgstr ""
 
-#: ../nethserver-enterprise-groups.xml.in.h:123
+#: ../nethserver-enterprise-groups.xml.in.h:125
 msgid "Localization of the Server Manager web interface"
 msgstr ""

--- a/po/it.po
+++ b/po/it.po
@@ -7,15 +7,15 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-07-03 15:50+0200\n"
-"PO-Revision-Date: 2018-10-09 10:56+0200\n"
+"POT-Creation-Date: 2019-10-02 15:06+0200\n"
+"PO-Revision-Date: 2019-10-02 15:10+0200\n"
 "Last-Translator: Davide Principi <davide.principi@nethesis.it>\n"
 "Language-Team: ITALIAN <support@nethesis.it>\n"
 "Language: it_IT\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 2.1.1\n"
+"X-Generator: Poedit 2.2.3\n"
 
 #: ../nethserver-enterprise-groups.xml.in.h:1
 msgid "Build system"
@@ -38,151 +38,159 @@ msgid "Backup of configuration and data"
 msgstr "Backup della configurazione del sistema e dei dati"
 
 #: ../nethserver-enterprise-groups.xml.in.h:6
+msgid "Backup restore"
+msgstr "Ripristino backup"
+
+#: ../nethserver-enterprise-groups.xml.in.h:7
+msgid "Module to restore backup of data"
+msgstr "Modulo per il ripristino del bakup dei dati"
+
+#: ../nethserver-enterprise-groups.xml.in.h:8
 msgid "Fax server"
 msgstr "Fax server"
 
-#: ../nethserver-enterprise-groups.xml.in.h:7
+#: ../nethserver-enterprise-groups.xml.in.h:9
 msgid "Configure HylaFax+ and manage IAX modems"
 msgstr "Configura HylaFax+ e gestisce i modem IAX"
 
-#: ../nethserver-enterprise-groups.xml.in.h:8
+#: ../nethserver-enterprise-groups.xml.in.h:10
 msgid "Basic firewall"
 msgstr "Firewall base"
 
-#: ../nethserver-enterprise-groups.xml.in.h:9
+#: ../nethserver-enterprise-groups.xml.in.h:11
 msgid "Configure network adapters and basic firewall"
 msgstr "Configura le interfacce di rete e il firewall base"
 
-#: ../nethserver-enterprise-groups.xml.in.h:10
+#: ../nethserver-enterprise-groups.xml.in.h:12
 msgid "File server"
 msgstr "File server"
 
-#: ../nethserver-enterprise-groups.xml.in.h:11
+#: ../nethserver-enterprise-groups.xml.in.h:13
 msgid "Daemons and tools for network file sharing"
 msgstr "Demoni e strumenti per la condivisione file in rete"
 
-#: ../nethserver-enterprise-groups.xml.in.h:12
+#: ../nethserver-enterprise-groups.xml.in.h:14
 msgid "FTP server"
 msgstr "Server FTP"
 
-#: ../nethserver-enterprise-groups.xml.in.h:13
+#: ../nethserver-enterprise-groups.xml.in.h:15
 msgid "Configure the FTP server (vsftpd)"
 msgstr "Configura il server FTP (vsftpd)"
 
-#: ../nethserver-enterprise-groups.xml.in.h:14
+#: ../nethserver-enterprise-groups.xml.in.h:16
 msgid "Account provider: OpenLDAP"
 msgstr "Provider account: OpenLDAP"
 
-#: ../nethserver-enterprise-groups.xml.in.h:15
+#: ../nethserver-enterprise-groups.xml.in.h:17
 msgid "Configure users and groups on OpenLDAP"
 msgstr "Configura utenti e gruppi su OpenLDAP"
 
-#: ../nethserver-enterprise-groups.xml.in.h:16
+#: ../nethserver-enterprise-groups.xml.in.h:18
 msgid "Account provider: Samba Active Directory"
 msgstr "Provider account: Samba Active Directory"
 
-#: ../nethserver-enterprise-groups.xml.in.h:17
+#: ../nethserver-enterprise-groups.xml.in.h:19
 msgid "Configure users and groups on Samba Active Directory"
 msgstr "Configura utenti e gruppi su Samba Active Directory"
 
-#: ../nethserver-enterprise-groups.xml.in.h:18
+#: ../nethserver-enterprise-groups.xml.in.h:20
 msgid "WebTop 5 groupware"
 msgstr "Groupware WebTop 5"
 
-#: ../nethserver-enterprise-groups.xml.in.h:19
+#: ../nethserver-enterprise-groups.xml.in.h:21
 msgid "Email"
 msgstr "Email"
 
-#: ../nethserver-enterprise-groups.xml.in.h:20
+#: ../nethserver-enterprise-groups.xml.in.h:22
 msgid "Email server and filter"
 msgstr "Server e filtri di posta elettronica"
 
-#: ../nethserver-enterprise-groups.xml.in.h:21
+#: ../nethserver-enterprise-groups.xml.in.h:23
 msgid "Roundcube web mail"
 msgstr "Roundcube web mail"
 
-#: ../nethserver-enterprise-groups.xml.in.h:22
+#: ../nethserver-enterprise-groups.xml.in.h:24
 msgid "SMTP proxy"
 msgstr "Proxy SMTP"
 
-#: ../nethserver-enterprise-groups.xml.in.h:23
+#: ../nethserver-enterprise-groups.xml.in.h:25
 msgid "Filter SMTP traffic with ClamAV and Rspamd"
 msgstr "Filtra il traffico SMTP con ClamAV e Rspamd"
 
-#: ../nethserver-enterprise-groups.xml.in.h:24
+#: ../nethserver-enterprise-groups.xml.in.h:26
 msgid "Instant messaging"
 msgstr "Messaggistica istantanea"
 
-#: ../nethserver-enterprise-groups.xml.in.h:25
+#: ../nethserver-enterprise-groups.xml.in.h:27
 msgid "XMPP/Jabber chat server"
 msgstr "Server di chat XMPP/Jabber"
 
-#: ../nethserver-enterprise-groups.xml.in.h:26
+#: ../nethserver-enterprise-groups.xml.in.h:28
 msgid "Print server"
 msgstr "Server di stampa"
 
-#: ../nethserver-enterprise-groups.xml.in.h:27
+#: ../nethserver-enterprise-groups.xml.in.h:29
 msgid "Print management server (CUPS)"
 msgstr "Servizio di gestione stampanti (CUPS)"
 
-#: ../nethserver-enterprise-groups.xml.in.h:28
+#: ../nethserver-enterprise-groups.xml.in.h:30
 msgid "Web server"
 msgstr "Server Web"
 
-#: ../nethserver-enterprise-groups.xml.in.h:29
+#: ../nethserver-enterprise-groups.xml.in.h:31
 msgid "Configuration tools for Apache web server"
 msgstr "Strumenti di configurazione per il server web Apache"
 
-#: ../nethserver-enterprise-groups.xml.in.h:30
+#: ../nethserver-enterprise-groups.xml.in.h:32
 msgid "Reverse proxy"
 msgstr "Reverse proxy"
 
-#: ../nethserver-enterprise-groups.xml.in.h:31
+#: ../nethserver-enterprise-groups.xml.in.h:33
 msgid "Configure Apache ProxyPass functionality"
 msgstr "Configura la funzione ProxyPass di Apache"
 
-#: ../nethserver-enterprise-groups.xml.in.h:32
+#: ../nethserver-enterprise-groups.xml.in.h:34
 msgid "Bandwidth monitor"
 msgstr "Monitoraggio banda"
 
-#: ../nethserver-enterprise-groups.xml.in.h:33
+#: ../nethserver-enterprise-groups.xml.in.h:35
 msgid "Configure and manage Ntopng"
 msgstr "Configurazione e gestione di Ntopng"
 
-#: ../nethserver-enterprise-groups.xml.in.h:34
+#: ../nethserver-enterprise-groups.xml.in.h:36
 msgid "UPS support"
 msgstr "Supporto UPS"
 
-#: ../nethserver-enterprise-groups.xml.in.h:35
+#: ../nethserver-enterprise-groups.xml.in.h:37
 msgid "UPS management and monitoring configuration"
 msgstr ""
 "Configurazione della gestione e del monitoraggio dei gruppi di continuità"
 
-#: ../nethserver-enterprise-groups.xml.in.h:36
+#: ../nethserver-enterprise-groups.xml.in.h:38
 msgid "Statistics"
 msgstr "Statistiche"
 
-#: ../nethserver-enterprise-groups.xml.in.h:37
+#: ../nethserver-enterprise-groups.xml.in.h:39
 msgid "Collect and analyse system statistics"
 msgstr "Registra e analizza le statistiche del sistema"
 
-#: ../nethserver-enterprise-groups.xml.in.h:38
+#: ../nethserver-enterprise-groups.xml.in.h:40
 msgid "Web proxy"
 msgstr "Proxy web"
 
-#: ../nethserver-enterprise-groups.xml.in.h:39
+#: ../nethserver-enterprise-groups.xml.in.h:41
 msgid "Squid web caching proxy configuration"
 msgstr "Configurazione Squid (web caching proxy)"
 
-#: ../nethserver-enterprise-groups.xml.in.h:40
+#: ../nethserver-enterprise-groups.xml.in.h:42
 msgid "Web filter"
 msgstr "Filtro web"
 
-#: ../nethserver-enterprise-groups.xml.in.h:41
+#: ../nethserver-enterprise-groups.xml.in.h:43
 msgid "Squid web content and virus filter"
 msgstr "Filtro web per contenuti e virus"
 
-#: ../nethserver-enterprise-groups.xml.in.h:42
+#: ../nethserver-enterprise-groups.xml.in.h:44
 msgid ""
 "Configure remote-access and site-to-site Virtual Private Networks (VPN) "
 "using OpenVPN"
@@ -190,63 +198,63 @@ msgstr ""
 "Configura le Virtual Private Network (VPN) per l'accesso di host o reti "
 "remote utilizzando OpenVPN"
 
-#: ../nethserver-enterprise-groups.xml.in.h:43
+#: ../nethserver-enterprise-groups.xml.in.h:45
 msgid "IPsec tunnels"
 msgstr "Tunnell IPsec"
 
-#: ../nethserver-enterprise-groups.xml.in.h:44
+#: ../nethserver-enterprise-groups.xml.in.h:46
 msgid "Site-to-site Virtual Private Networks (VPN) using IPsec"
 msgstr ""
 "Configura le Virtual Private Network (VPN) site-to-site utilizzando IPsec"
 
-#: ../nethserver-enterprise-groups.xml.in.h:45
+#: ../nethserver-enterprise-groups.xml.in.h:47
 msgid "MariaDB (MySQL) server"
 msgstr "Server MariaDB (MySQL)"
 
-#: ../nethserver-enterprise-groups.xml.in.h:46
+#: ../nethserver-enterprise-groups.xml.in.h:48
 msgid "Configuration tools for MariaDB (MySQL)"
 msgstr "Strumenti di configurazione per MariaDB (MySQL)"
 
-#: ../nethserver-enterprise-groups.xml.in.h:47
+#: ../nethserver-enterprise-groups.xml.in.h:49
 msgid "Intrusion Prevention System"
 msgstr "Intrusion Prevention System"
 
-#: ../nethserver-enterprise-groups.xml.in.h:48
+#: ../nethserver-enterprise-groups.xml.in.h:50
 msgid "Monitor and block network traffic for malicious activity"
 msgstr ""
 "Controlla e blocca il traffico di rete proveniente da attività malevoli"
 
-#: ../nethserver-enterprise-groups.xml.in.h:49
+#: ../nethserver-enterprise-groups.xml.in.h:51
 msgid "Deep packet inspection (DPI)"
 msgstr "Deep packet inspection (DPI)"
 
-#: ../nethserver-enterprise-groups.xml.in.h:50
+#: ../nethserver-enterprise-groups.xml.in.h:52
 msgid "Filter network traffic by analyzing the packets payload"
 msgstr "Filtra il traffico di rete analizzando il contenuto dei pacchetti"
 
-#: ../nethserver-enterprise-groups.xml.in.h:51
+#: ../nethserver-enterprise-groups.xml.in.h:53
 msgid "POP3 proxy"
 msgstr "Proxy POP3"
 
-#: ../nethserver-enterprise-groups.xml.in.h:52
+#: ../nethserver-enterprise-groups.xml.in.h:54
 msgid "Intercept POP3 connections and scan messages for virus and spam"
 msgstr ""
 "Intercetta le connessioni POP3 e scansiona i messaggi alla ricerca di virus "
 "e spam"
 
-#: ../nethserver-enterprise-groups.xml.in.h:53
+#: ../nethserver-enterprise-groups.xml.in.h:55
 msgid "SNMP server"
 msgstr "Server SNMP"
 
-#: ../nethserver-enterprise-groups.xml.in.h:54
+#: ../nethserver-enterprise-groups.xml.in.h:56
 msgid "Configure the SNMP server"
 msgstr "Configura il server SNMP"
 
-#: ../nethserver-enterprise-groups.xml.in.h:55
+#: ../nethserver-enterprise-groups.xml.in.h:57
 msgid "Nextcloud"
 msgstr "Nextcloud"
 
-#: ../nethserver-enterprise-groups.xml.in.h:56
+#: ../nethserver-enterprise-groups.xml.in.h:58
 msgid ""
 "Configure Nextcloud, universal access to your files via the web, your "
 "computer or your mobile devices - wherever you are"
@@ -254,276 +262,275 @@ msgstr ""
 "Configura NextCloud - accesso completo ai propri file via web, computer o "
 "dispositivi mobili - da qualsiasi luogo"
 
-#: ../nethserver-enterprise-groups.xml.in.h:57
+#: ../nethserver-enterprise-groups.xml.in.h:59
 msgid "POP3 connector"
 msgstr "Connettore POP3"
 
-#: ../nethserver-enterprise-groups.xml.in.h:58
+#: ../nethserver-enterprise-groups.xml.in.h:60
 msgid "Fetch messages from external email accounts with POP3 or IMAP access"
 msgstr "Scarica i messaggi da un account email esterno con accesso POP3 o IMAP"
 
-#: ../nethserver-enterprise-groups.xml.in.h:59
+#: ../nethserver-enterprise-groups.xml.in.h:61
 msgid "German language"
 msgstr "Lingua Tedesca"
 
-#: ../nethserver-enterprise-groups.xml.in.h:60
+#: ../nethserver-enterprise-groups.xml.in.h:62
 msgid "Server Manager German localization"
 msgstr "Traduzione Server Manager: Tedesco"
 
-#: ../nethserver-enterprise-groups.xml.in.h:61
+#: ../nethserver-enterprise-groups.xml.in.h:63
 msgid "Greek language"
 msgstr "Lingua Greca"
 
-#: ../nethserver-enterprise-groups.xml.in.h:62
+#: ../nethserver-enterprise-groups.xml.in.h:64
 msgid "Server Manager Greek localization"
 msgstr "Traduzione Server Manager: Greco"
 
-#: ../nethserver-enterprise-groups.xml.in.h:63
+#: ../nethserver-enterprise-groups.xml.in.h:65
 msgid "Spanish language"
 msgstr "Lingua Spagnola"
 
-#: ../nethserver-enterprise-groups.xml.in.h:64
+#: ../nethserver-enterprise-groups.xml.in.h:66
 msgid "Server Manager Spanish localization"
 msgstr "Traduzione Server Manager: Spagnolo"
 
-#: ../nethserver-enterprise-groups.xml.in.h:65
+#: ../nethserver-enterprise-groups.xml.in.h:67
 msgid "French language"
 msgstr "Lingua Francese"
 
-#: ../nethserver-enterprise-groups.xml.in.h:66
+#: ../nethserver-enterprise-groups.xml.in.h:68
 msgid "Server Manager French localization"
 msgstr "Traduzione Server Manager: Francese"
 
-#: ../nethserver-enterprise-groups.xml.in.h:67
+#: ../nethserver-enterprise-groups.xml.in.h:69
 msgid "Hungarian language"
 msgstr "Lingua Ungherese"
 
-#: ../nethserver-enterprise-groups.xml.in.h:68
+#: ../nethserver-enterprise-groups.xml.in.h:70
 msgid "Server Manager Hungarian localization"
 msgstr "Traduzione Server Manager: Ungherese"
 
-#: ../nethserver-enterprise-groups.xml.in.h:69
+#: ../nethserver-enterprise-groups.xml.in.h:71
 msgid "Italian language"
 msgstr "Lingua Italiana"
 
-#: ../nethserver-enterprise-groups.xml.in.h:70
+#: ../nethserver-enterprise-groups.xml.in.h:72
 msgid "Server Manager Italian localization"
 msgstr "Traduzione Server Manager: Italiano"
 
-#: ../nethserver-enterprise-groups.xml.in.h:71
+#: ../nethserver-enterprise-groups.xml.in.h:73
 msgid "Dutch language"
 msgstr "Lingua Olandese"
 
-#: ../nethserver-enterprise-groups.xml.in.h:72
+#: ../nethserver-enterprise-groups.xml.in.h:74
 msgid "Server Manager Dutch localization"
 msgstr "Traduzione Server Manager: Olandese"
 
-#: ../nethserver-enterprise-groups.xml.in.h:73
+#: ../nethserver-enterprise-groups.xml.in.h:75
 msgid "Portuguese language"
 msgstr "Lingua Portoghese"
 
-#: ../nethserver-enterprise-groups.xml.in.h:74
+#: ../nethserver-enterprise-groups.xml.in.h:76
 msgid "Server Manager Portuguese localization"
 msgstr "Traduzione Server Manager: Portoghese"
 
-#: ../nethserver-enterprise-groups.xml.in.h:75
+#: ../nethserver-enterprise-groups.xml.in.h:77
 msgid "Russian language"
 msgstr "Lingua Russa"
 
-#: ../nethserver-enterprise-groups.xml.in.h:76
+#: ../nethserver-enterprise-groups.xml.in.h:78
 msgid "Server Manager Russian localization"
 msgstr "Traduzione Server Manager: Russo"
 
-#: ../nethserver-enterprise-groups.xml.in.h:77
+#: ../nethserver-enterprise-groups.xml.in.h:79
 msgid "Turkish language"
 msgstr "Lingua Turca"
 
-#: ../nethserver-enterprise-groups.xml.in.h:78
+#: ../nethserver-enterprise-groups.xml.in.h:80
 msgid "Server Manager Turkish localization"
 msgstr "Traduzione Server Manager: Turco"
 
-#: ../nethserver-enterprise-groups.xml.in.h:79
+#: ../nethserver-enterprise-groups.xml.in.h:81
 msgid "Serbian language"
 msgstr "Lingua Serba"
 
-#: ../nethserver-enterprise-groups.xml.in.h:80
+#: ../nethserver-enterprise-groups.xml.in.h:82
 msgid "Server Manager Serbian localization"
 msgstr "Traduzione Server Manager: Serbo"
 
-#: ../nethserver-enterprise-groups.xml.in.h:81
+#: ../nethserver-enterprise-groups.xml.in.h:83
 msgid "Phonebook"
 msgstr "Rubrica"
 
-#: ../nethserver-enterprise-groups.xml.in.h:82
+#: ../nethserver-enterprise-groups.xml.in.h:84
 msgid "Centralized Phonebook"
 msgstr "Rubrica Centralizzata"
 
-#: ../nethserver-enterprise-groups.xml.in.h:83
+#: ../nethserver-enterprise-groups.xml.in.h:85
 msgid "Centralized HotSpot"
 msgstr "Hotspot centralizzato"
 
-#: ../nethserver-enterprise-groups.xml.in.h:84
+#: ../nethserver-enterprise-groups.xml.in.h:86
 msgid "Portal for centralized hotspot configuration"
 msgstr "Portale per la configurazione dell'hotspot centralizzato"
 
-#: ../nethserver-enterprise-groups.xml.in.h:85
+#: ../nethserver-enterprise-groups.xml.in.h:87
 msgid "Cloud content filter"
 msgstr "Filtro contenuti cloud"
 
-#: ../nethserver-enterprise-groups.xml.in.h:86
+#: ../nethserver-enterprise-groups.xml.in.h:88
 msgid "Cloud-based web content filter"
 msgstr "Filtro contenuti web cloud"
 
-#: ../nethserver-enterprise-groups.xml.in.h:87
+#: ../nethserver-enterprise-groups.xml.in.h:89
 msgid "Weekly report"
 msgstr "Report settimanale"
 
-#: ../nethserver-enterprise-groups.xml.in.h:88
+#: ../nethserver-enterprise-groups.xml.in.h:90
 msgid "Weekly report about system status"
 msgstr "Report settimanale sullo stato del sistema"
 
-#: ../nethserver-enterprise-groups.xml.in.h:89
+#: ../nethserver-enterprise-groups.xml.in.h:91
 msgid "NethSecurity 1.5 migration"
 msgstr "Migrazione NethSecurity 1.5"
 
-#: ../nethserver-enterprise-groups.xml.in.h:90
+#: ../nethserver-enterprise-groups.xml.in.h:92
 msgid "Migrations tools from NethSecurity 1.5"
 msgstr "Strumenti di migrazione da NethSecurity 1.5"
 
-#: ../nethserver-enterprise-groups.xml.in.h:91
+#: ../nethserver-enterprise-groups.xml.in.h:93
 msgid "NethVoice 11"
 msgstr "NethVoice 11"
 
-#: ../nethserver-enterprise-groups.xml.in.h:92
+#: ../nethserver-enterprise-groups.xml.in.h:94
 msgid "Asterisk PBX"
 msgstr "Centralino VOIP basato su Asterisk"
 
-#: ../nethserver-enterprise-groups.xml.in.h:93
+#: ../nethserver-enterprise-groups.xml.in.h:95
 msgid "NethVoice 14 with NethCTI 3"
 msgstr "NethVoice 14 con NethCTI 3"
 
-#: ../nethserver-enterprise-groups.xml.in.h:94
+#: ../nethserver-enterprise-groups.xml.in.h:96
 msgid "PBX configuration with Computer Telephony Integration web application"
 msgstr ""
 "Configurazione PBX con applicazione web di integrazione al sistema "
 "telefonico aziendale (CTI)"
 
-#: ../nethserver-enterprise-groups.xml.in.h:95
+#: ../nethserver-enterprise-groups.xml.in.h:97
 msgid "NethCTI QManager"
 msgstr "NethCTI QManager"
 
-#: ../nethserver-enterprise-groups.xml.in.h:96
+#: ../nethserver-enterprise-groups.xml.in.h:98
 msgid "Queue Manager is the application for queue supervisor"
 msgstr "Queue Manager è l'applicazione per il supervisore delle code"
 
-#: ../nethserver-enterprise-groups.xml.in.h:97
+#: ../nethserver-enterprise-groups.xml.in.h:99
 msgid "NethCTI 2"
 msgstr "NethCTI 2"
 
-#: ../nethserver-enterprise-groups.xml.in.h:98
+#: ../nethserver-enterprise-groups.xml.in.h:100
 msgid "Computer Telephony Integration"
 msgstr "Integrazione sistema telefonico aziendale"
 
-#: ../nethserver-enterprise-groups.xml.in.h:99
+#: ../nethserver-enterprise-groups.xml.in.h:101
 msgid "NethHotel 11"
 msgstr "NethHotel 11"
 
-#: ../nethserver-enterprise-groups.xml.in.h:100
+#: ../nethserver-enterprise-groups.xml.in.h:102
 msgid "Hotel Management Interface"
 msgstr "Interfaccia Gestione Hotel"
 
-#: ../nethserver-enterprise-groups.xml.in.h:101
+#: ../nethserver-enterprise-groups.xml.in.h:103
 msgid "Mattermost"
 msgstr "Mattermost"
 
-#: ../nethserver-enterprise-groups.xml.in.h:102
+#: ../nethserver-enterprise-groups.xml.in.h:104
 msgid "Mattermost Team Edition"
 msgstr "Mattermost Team Edition"
 
-#: ../nethserver-enterprise-groups.xml.in.h:103
+#: ../nethserver-enterprise-groups.xml.in.h:105
 msgid "NethSpot"
 msgstr "NethSpot"
 
-#: ../nethserver-enterprise-groups.xml.in.h:104
+#: ../nethserver-enterprise-groups.xml.in.h:106
 msgid "Nethesis Hotspot"
 msgstr "Nethesis Hotspot"
 
-#: ../nethserver-enterprise-groups.xml.in.h:105
+#: ../nethserver-enterprise-groups.xml.in.h:107
 msgid "NethSpot Integrations"
 msgstr "Integrazioni NethSpot"
 
-#: ../nethserver-enterprise-groups.xml.in.h:106
-#, fuzzy
+#: ../nethserver-enterprise-groups.xml.in.h:108
 msgid "NethSpot extra integrations"
-msgstr "Migrazione NethSecurity 1.5"
+msgstr "Integrazioni extra NethSpot"
 
-#: ../nethserver-enterprise-groups.xml.in.h:107
+#: ../nethserver-enterprise-groups.xml.in.h:109
 msgid "Fail2ban"
 msgstr "Fail2ban"
 
-#: ../nethserver-enterprise-groups.xml.in.h:108
+#: ../nethserver-enterprise-groups.xml.in.h:110
 msgid "Fail2ban scans log files and bans IPs with failed login"
 msgstr "Fail2ban analizza i file di log e vieta gli IP con login falliti"
 
-#: ../nethserver-enterprise-groups.xml.in.h:109
+#: ../nethserver-enterprise-groups.xml.in.h:111
 msgid "New Server Manager (Beta)"
 msgstr "Nuovo Server Manager (Beta)"
 
-#: ../nethserver-enterprise-groups.xml.in.h:110
+#: ../nethserver-enterprise-groups.xml.in.h:112
 msgid "New Server Manager based on Cockpit"
 msgstr "Nuovo Server Manager basato su Cockpit"
 
-#: ../nethserver-enterprise-groups.xml.in.h:111
-msgid "Netdata"
-msgstr ""
-
-#: ../nethserver-enterprise-groups.xml.in.h:112
-msgid "Real-time performance monitoring"
-msgstr ""
-
 #: ../nethserver-enterprise-groups.xml.in.h:113
+msgid "Netdata"
+msgstr "Netdata"
+
+#: ../nethserver-enterprise-groups.xml.in.h:114
+msgid "Real-time performance monitoring"
+msgstr "Monitoraggio real-time delle performance"
+
+#: ../nethserver-enterprise-groups.xml.in.h:115
 #, fuzzy
 msgid "Report (Beta)"
 msgstr "Report (Beta)"
 
-#: ../nethserver-enterprise-groups.xml.in.h:114
+#: ../nethserver-enterprise-groups.xml.in.h:116
 #, fuzzy
 msgid "Reports on system usage"
 msgstr "Report settimanale sullo stato del sistema"
 
-#: ../nethserver-enterprise-groups.xml.in.h:115
+#: ../nethserver-enterprise-groups.xml.in.h:117
 msgid "Base system"
 msgstr "Sistema base"
 
-#: ../nethserver-enterprise-groups.xml.in.h:116
+#: ../nethserver-enterprise-groups.xml.in.h:118
 msgid "Common packages to all products"
 msgstr "Pacchetti comuni a tutti i prodotti"
 
-#: ../nethserver-enterprise-groups.xml.in.h:117
+#: ../nethserver-enterprise-groups.xml.in.h:119
 msgid "NethService"
 msgstr "NethService"
 
-#: ../nethserver-enterprise-groups.xml.in.h:118
+#: ../nethserver-enterprise-groups.xml.in.h:120
 msgid "Small and Medium Enterprises (SME) oriented Linux distribution"
 msgstr "Distribuzione Linux per la piccola e media impresa"
 
-#: ../nethserver-enterprise-groups.xml.in.h:119
+#: ../nethserver-enterprise-groups.xml.in.h:121
 msgid "NethSecurity"
 msgstr "NethSecurity"
 
-#: ../nethserver-enterprise-groups.xml.in.h:120
+#: ../nethserver-enterprise-groups.xml.in.h:122
 msgid "UTM Firewall"
 msgstr "Firewall UTM (Unified Threat Management)"
 
-#: ../nethserver-enterprise-groups.xml.in.h:121
+#: ../nethserver-enterprise-groups.xml.in.h:123
 msgid "NethVoice"
 msgstr "NethVoice"
 
-#: ../nethserver-enterprise-groups.xml.in.h:122
+#: ../nethserver-enterprise-groups.xml.in.h:124
 msgid "Languages"
 msgstr "Lingue"
 
-#: ../nethserver-enterprise-groups.xml.in.h:123
+#: ../nethserver-enterprise-groups.xml.in.h:125
 msgid "Localization of the Server Manager web interface"
 msgstr "Traduzioni per Server Manager"
 


### PR DESCRIPTION
To avoid missing Backup application installed in software center, the `nethserver-restore-data` dependency should be removed and added as a new group.