### PR TITLE
Additional g729 codec for Asterisk 13

### DIFF
--- a/nethserver-enterprise-groups.xml.in
+++ b/nethserver-enterprise-groups.xml.in
@@ -994,6 +994,7 @@
       <packagereq type="optional">queuereport</packagereq>
       <packagereq type="optional">neth-hotel14</packagereq>
       <packagereq type="optional">inboundreport</packagereq>
+      <packagereq type="optional">asterisk-codecs-g729</packagereq>
     </packagelist>
   </group>
 


### PR DESCRIPTION
The Cockpit Software Center installs all optional packages automatically. If the Digium implementation is wanted the `asterisk-codecs-g729` can be removed easily.

https://github.com/nethesis/dev/issues/5896