### PR TITLE
Add DAHDI group

### DIFF
--- a/nethserver-enterprise-groups.xml.in
+++ b/nethserver-enterprise-groups.xml.in
@@ -1164,7 +1164,7 @@
 
   <group>
       <id>dahdi</id>
-      <_name>DAHDI divers and tools</_name>
+      <_name>DAHDI drivers and tools</_name>
       <_description>Support Digium Asterisk Hardware Device Interface</_description>
       <default>false</default>
       <uservisible>true</uservisible>

--- a/nethserver-enterprise-groups.xml.in
+++ b/nethserver-enterprise-groups.xml.in
@@ -1162,6 +1162,19 @@
       </packagelist>
   </group>
 
+  <group>
+      <id>dahdi</id>
+      <_name>DAHDI divers and tools</_name>
+      <_description>Support Digium Asterisk Hardware Device Interface</_description>
+      <default>false</default>
+      <uservisible>true</uservisible>
+      <packagelist>
+        <packagereq type="mandatory">kmod-dahdi-linux</packagereq>
+        <packagereq type="mandatory">dahdi-linux</packagereq>
+        <packagereq type="mandatory">dahdi-firmware</packagereq>
+        <packagereq type="mandatory">dahdi-tools</packagereq>
+      </packagelist>
+  </group>
 
 <!-- NETHESIS GROUPS END -->
 
@@ -1260,6 +1273,7 @@
       <groupid>nethserver-nethvoice14</groupid>
       <groupid>neth-hotel14</groupid>
       <groupid>qmanager</groupid>
+      <groupid>dahdi</groupid>
     </grouplist>
   </category>
 


### PR DESCRIPTION
DAHDI is no more a dependency for freepbx package

NethServer/dev#6319

**Note**: remember to push translations to transifex after merge